### PR TITLE
Remove gitlfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.parquet filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -27,8 +27,6 @@ jobs:
         python-version: "3.10" 
     - name: Install dependencies
       run: |
-        sudo apt-get install git-lfs
-        git lfs install
         python -m pip install --upgrade pip
         pip install flake8
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
@@ -40,9 +38,9 @@ jobs:
    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
    #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-    # - name: Download and prepare data for tests
-    #   run: |
-    #     make download_and_initialize_data
+    - name: Download and prepare data for tests
+      run: |
+        make download_and_initialize_data
     - name: Test with pytest
       run: |
         make launch_test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@ install_library:
 	pip install -r requirements.txt
 	pip install -e .
 download_and_initialize_data:
-	python ./iris_insee_utils/download_data.py
+	python ./iris_insee_utils/get_iris_contours_data.py
 launch_test:
 	pytest -n auto --cov=iris_insee_utils --cov-report=xml

--- a/data/transformed/iris_2018.parquet
+++ b/data/transformed/iris_2018.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f670f2b862ae3f7f63ca8e15ee209b1720810d4d32000d01288d69a0a37927c0
-size 44620646

--- a/data/transformed/iris_2019.parquet
+++ b/data/transformed/iris_2019.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dcf0fda8bc8045d0c8b8408565426dd494d6f2e981adb05f8a86e07bcda1b4fb
-size 42125123

--- a/data/transformed/iris_2020.parquet
+++ b/data/transformed/iris_2020.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44a13dc939d8263c62b56ad9dd3bc31ff84ad69d9057827b862cd7ed95802f12
-size 44848678

--- a/data/transformed/iris_2021.parquet
+++ b/data/transformed/iris_2021.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82dbb5b42810efd559bef3e17f629351e58ed252c5479a265be498df8eb94018
-size 44845852

--- a/data/transformed/iris_2022.parquet
+++ b/data/transformed/iris_2022.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b835391ec0fcc74c1a878466fb32695e5164db5b2d8bb1cdae725724badd368a
-size 44842901

--- a/data/transformed/iris_2023.parquet
+++ b/data/transformed/iris_2023.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f4fb4f0463679ffe5d55187c1786721684582b9c78ec3fdd3f2220df75ff05d
-size 36216712

--- a/iris_insee_utils/get_iris_contours_data.py
+++ b/iris_insee_utils/get_iris_contours_data.py
@@ -1,0 +1,44 @@
+"Will get the contour data for the given year by either reading it from cache in data/transformed or by downloading it from iris_insee_utils_data and recording it in data/transformed."
+import geopandas as gpd
+import iris_insee_utils
+import requests
+from loguru import logger
+from pathlib import Path
+
+def read_or_download_iris_contour_data(iris_year: int) -> gpd.GeoDataFrame:
+    """
+    Get the contour data for the given year by either reading it from cache in data/transformed or by downloading it from iris_insee_utils_data and recording it in data/transformed.
+
+    Parameters
+    ----------
+    iris_year : int
+        The year of the IRIS data to be used.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        A GeoDataFrame containing the IRIS contour data for the specified year.
+    """
+    try:
+            df_ign_map = gpd.read_parquet(
+                iris_insee_utils.__path__[0] + f"/../data/transformed/iris_{iris_year}.parquet"
+            )
+    except FileNotFoundError:
+        logger.info("The file iris_{iris_year}.parquet does not exist. Will try to download it and cache it.")
+        url = f"https://github.com/adrienpacifico/iris_insee_utils_data/raw/refs/heads/main/data/primary/iris_{iris_year}.parquet"
+        response = requests.get(url)
+        response.raise_for_status()
+
+        data_dir = Path(iris_insee_utils.__path__[0]).parent / "data" / "transformed"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        file_path = data_dir / f"iris_{iris_year}.parquet"
+
+        with open(file_path, "wb") as file:
+            file.write(response.content)
+
+        df_ign_map = gpd.read_parquet(file_path)
+    return df_ign_map
+
+if __name__ == "__main__":
+    for year in range(2018, 2024):
+        read_or_download_iris_contour_data(iris_year=year)

--- a/iris_insee_utils/gps_to_iris.py
+++ b/iris_insee_utils/gps_to_iris.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 import geopandas as gpd
-
+from iris_insee_utils.get_iris_contours_data import read_or_download_iris_contour_data
 import iris_insee_utils
 
 
@@ -36,9 +36,7 @@ def gps_to_iris(
                        geometry  index_right INSEE_COM  ...  CODE_IRIS              NOM_IRIS TYP_IRIS
     0  POINT (5.36222 43.41523)        37408     13071  ...  130710101  Cd6-Plan de Campagne        A
     """
-    df_ign_map = gpd.read_parquet(
-        iris_insee_utils.__path__[0] + f"/../data/transformed/iris_{iris_year}.parquet"
-    )
+    df_ign_map = read_or_download_iris_contour_data(iris_year)
     df_ign_map = df_ign_map.to_crs(epsg=4326)
     gdf = gpd.GeoDataFrame(geometry=gpd.points_from_xy([long], [lat]))
 

--- a/iris_insee_utils/iris_map.py
+++ b/iris_insee_utils/iris_map.py
@@ -2,6 +2,7 @@
 
 import os
 
+from iris_insee_utils.get_iris_contours_data import read_or_download_iris_contour_data
 import iris_insee_utils
 from iris_insee_utils.gps_to_iris import gps_to_iris
 import pandas as pd
@@ -59,12 +60,7 @@ def plot_folium_map(
                     - The map is returned as a Folium map object.
     """
 
-    file_path = os.path.join(
-        os.path.dirname(iris_insee_utils.__file__),
-        f"../data/transformed/iris_{iris_year}.parquet",
-    )
-
-    df_map = gpd.read_parquet(file_path).to_crs(
+    df_map = read_or_download_iris_contour_data(iris_year).to_crs(
         epsg=4326
     )  # TODO: add this to the cleaning function
     df_map["NOM_COM"] = (


### PR DESCRIPTION
Gitlfs free tier quotas on github are very low (less than 1GB of download per month), switch to a dedicated repo for data (inspired by what seaborn is doing for its examples datasets).

Data are downloaded from repo https://github.com/adrienpacifico/iris_insee_utils_data